### PR TITLE
reformat: galois field, variables

### DIFF
--- a/Formal/DF_1/DF_1_4.lean
+++ b/Formal/DF_1/DF_1_4.lean
@@ -1,22 +1,18 @@
-import Mathlib.Algebra.Field.Defs
+import Mathlib.FieldTheory.Finite.GaloisField
 import Mathlib.LinearAlgebra.Matrix.GeneralLinearGroup.Defs
-
-
-variable {p : ℕ} [Fact (Nat.Prime p)]
-instance : Field (ZMod p) := ZMod.instField p
 
 /--
 $\mathrm{GL}_{2}(\mathbb{F}_{2})$ has 6 elements.
 
 Contributor: Seewoo Lee
 -/
-theorem DF_1_4_1 : Nat.card (Matrix.GeneralLinearGroup (Fin 2) (ZMod 2)) = 6 := by
-  sorry
+theorem DF_1_4_1 : Nat.card (Matrix.GeneralLinearGroup (Fin 2) (GaloisField 2 1)) = 6 := by sorry
 
 /--
-$\mathrm{GL}_{2}(\mathbb{F}_{p})$ has $p^{4} - p^{3} - p^{2} + p$ elements.
+For a prime $p$, $\mathrm{GL}_{2}(\mathbb{F}_{p})$ has $p^{4} - p^{3} - p^{2} + p$ elements.
 
 Contributor: Seewoo Lee
 -/
-theorem DF_1_4_7 : Nat.card (Matrix.GeneralLinearGroup (Fin 2) (ZMod p)) = p^4 - p^3 - p^2 + p := by
+theorem DF_1_4_7 {p : ℕ} [Fact (Nat.Prime p)] : Nat.card (Matrix.GeneralLinearGroup (Fin 2) (GaloisField p 1))
+    = p^4 - p^3 - p^2 + p := by
   sorry

--- a/Formal/DF_13/DF_13_1.lean
+++ b/Formal/DF_13/DF_13_1.lean
@@ -1,8 +1,4 @@
-import Mathlib.Algebra.Polynomial.Basic
-import Mathlib.Algebra.Prime.Defs
-import Mathlib.Data.ZMod.Basic
-import Mathlib.Algebra.Polynomial.Degree.Definitions
-import Mathlib.Algebra.Polynomial.Eval.Defs
+import Mathlib.FieldTheory.Finite.GaloisField
 
 open scoped Polynomial
 
@@ -27,7 +23,7 @@ Show that $p(x) = x^3 + x + 1$ is irreducible in $𝔽_2[x]$.
 
 Contributor: Yeachan Park
 -/
-theorem DF_13_1_3 : Irreducible (X^3 + X + 1 : Polynomial (ZMod 2)) := by
+theorem DF_13_1_3 : Irreducible (X^3 + X + 1 : Polynomial (GaloisField 2 1)) := by
   sorry
 
 /--

--- a/Formal/DF_2/DF_2_1.lean
+++ b/Formal/DF_2/DF_2_1.lean
@@ -1,13 +1,11 @@
 import Mathlib.Algebra.Group.Subgroup.Defs
 import Mathlib.SetTheory.Cardinal.Finite
 
-variable {G : Type*} [Group G]
-
 /--
 A group $G$ cannot have a subgroup $H$ with $|H|=n-1$, where $n=|G|>2$.
 
 Contributor: Byung-Hak Hwang
 -/
-theorem DF_2_1_5 (h : Nat.card G > 2) :
+theorem DF_2_1_5 [Group G] (h : Nat.card G > 2) :
   ¬∃ (H : Subgroup G), Nat.card H = Nat.card G - 1 := by
   sorry

--- a/Formal/DF_4/DF_4_2_8.lean
+++ b/Formal/DF_4/DF_4_2_8.lean
@@ -1,5 +1,11 @@
 import Mathlib.GroupTheory.Index
 
-variable {G : Type*} [Group G]
+/--
+If $H$ is a finite index subgroup of $G$ of index $n$, then there exists
+a normal subgroup $K$ of $G$ such that $K \leq H$ and $[G : K] \leq n!$.
 
-theorem DF_4_2_8 {H : Subgroup G} {n : Nat} (hH : H.index = n) : ∃ (K : Subgroup G), K.Normal ∧ K ≤ H ∧ K.index ≤ Nat.factorial n := sorry
+Contributor: Kyu-Hwan Lee, Seewoo Lee
+-/
+theorem DF_4_2_8 [Group G] {H : Subgroup G} {n : Nat} (hH : H.index = n)
+    : ∃ (K : Subgroup G), K.Normal ∧ K ≤ H ∧ K.index ≤ Nat.factorial n := by
+  sorry

--- a/Formal/DF_7/DF_7_1.lean
+++ b/Formal/DF_7/DF_7_1.lean
@@ -1,18 +1,16 @@
 import Mathlib.Algebra.Ring.Units
 
 
-variable {R : Type*} [Ring R]
-
 /--
 For a ring $R$ with $1$, $(-1)^{2} = 1$.
 
 Contributor: Seewoo Lee
 -/
-theorem DF_7_1_1 : (-1 : R) ^ 2 = (1 : R) := by sorry
+theorem DF_7_1_1 [Ring R] : (-1 : R) ^ 2 = (1 : R) := by sorry
 
 /--
 For a ring $R$ with $1$, if $u$ is a unit, then $-u$ is also a unit.
 
 Contributor: Seewoo Lee
 -/
-theorem DF_7_1_2 (u : R) : IsUnit u → IsUnit (-u) := by sorry
+theorem DF_7_1_2 [Ring R] (u : R) : IsUnit u → IsUnit (-u) := by sorry


### PR DESCRIPTION
- Use `GaloisField` for finite fields (instead of `ZMod`
- Move variables to statements